### PR TITLE
Settings for parsing proxy headers

### DIFF
--- a/webapp/settings.py
+++ b/webapp/settings.py
@@ -25,6 +25,9 @@ SECRET_KEY = os.environ.get('SECRET_KEY', 'no_secret')
 ALLOWED_HOSTS = ['*']
 DEBUG = os.environ.get('DJANGO_DEBUG', 'false').lower() == 'true'
 
+USE_X_FORWARDED_HOST = True
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+
 LANGUAGE_CODE = 'en-us'
 TIME_ZONE = 'UTC'
 USE_I18N = False


### PR DESCRIPTION
When behind running behind a proxy, this will help the app pick up on the original host and protocol that was used to request the site.

For you @WillMoggridge.